### PR TITLE
Work around s3 bucket change in upstream osquery

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'dev+chef-osquery@dwolla.com'
 license 'Apache-2.0'
 description 'Install and configure osquery (osquery.io)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.9.0'
+version '1.9.1'
 
 %w[ubuntu centos redhat mac_os_x amazon].each do |os|
   supports os

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -35,7 +35,7 @@ action :install_centos do
   package_action = new_resource.upgrade ? :upgrade : :install
 
   yum_repository 'osquery' do
-    baseurl 'https://s3.amazonaws.com/osquery-packages/rpm/$basearch/'
+    baseurl 'https://osquery-packages.s3.amazonaws.com/rpm/$basearch/'
     gpgkey 'https://pkg.osquery.io/rpm/GPG'
     action :create
   end
@@ -51,7 +51,7 @@ action :install_amazon do
   package_action = new_resource.upgrade ? :upgrade : :install
 
   yum_repository 'osquery' do
-    baseurl 'https://s3.amazonaws.com/osquery-packages/rpm/$basearch/'
+    baseurl 'https://osquery-packages.s3.amazonaws.com/rpm/$basearch/'
     gpgkey 'https://pkg.osquery.io/rpm/GPG'
     action :create
   end


### PR DESCRIPTION
Fixing the URL for the osquery rpm packages that seem to have moved in https://github.com/osquery/osquery/issues/6653